### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/flowlayoutmanager/src/main/AndroidManifest.xml
+++ b/flowlayoutmanager/src/main/AndroidManifest.xml
@@ -1,10 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.xiaofeng.flowlayoutmanager">
 
-    <application android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
->
+    <application
+        android:supportsRtl="true">
 
     </application>
 


### PR DESCRIPTION
Adding the library to my project complains during Android Manifest merge because my application explicitly disables allowBackup. As this is a library, there's no reason for it to define allowBackup and label since the applications do that.